### PR TITLE
Use VISA gengi instead of Almennt gengi from li.is

### DIFF
--- a/endpoints/currency.js
+++ b/endpoints/currency.js
@@ -50,7 +50,7 @@ var getCurrencyBase = function(cb) {
 
 var fetchCurrencyBase = function(cb) {
   request.get({
-    url: 'http://www.landsbankinn.is/modules/markets/services/XMLGengi.asmx/NyjastaGengiByType?strTegund=A'
+    url: 'http://www.landsbankinn.is/modules/markets/services/XMLGengi.asmx/NyjastaGengiByType?strTegund=V'
   }, function(err, response, data) {
     if(err || response.statusCode !== 200) {
       cb(err);


### PR DESCRIPTION
Officially suggesting using `VISA gengi` instead of `Almennt gengi` from [li.is](http://li.is), since that value is what most people in our use case are really looking for.

Any objections @olafurnielsen ?